### PR TITLE
Improve RFC password documentation

### DIFF
--- a/DIFF_20250624_025516.md
+++ b/DIFF_20250624_025516.md
@@ -1,0 +1,5 @@
+# Diff 20250624_025516
+- Added `RFC_PASSWORD` variable to `example.env` for remote function calls
+- Documented `.env` setup and `RFC_PASSWORD` in README quick start
+- Documented `RFC_PASSWORD` requirement in installation guide
+- Improved missing password error message in `runtime.py`

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ docker run -p 50001:80 frdel/agent-zero-run
 # Visit http://localhost:50001 to start
 ```
 
+Before starting, copy `example.env` to `.env` and set any API keys you plan to use.
+If you intend to run Agent Zero locally alongside a Docker instance, set a value
+for `RFC_PASSWORD` in your `.env` file to avoid `No RFC password` errors when
+remote function calls are triggered.
+
 ## 🐳 Fully Dockerized, with Speech-to-Text and TTS
 
 ![Settings](docs/res/settings-page-ui.png)

--- a/RECOMMENDATIONS_20250624_025516.md
+++ b/RECOMMENDATIONS_20250624_025516.md
@@ -1,0 +1,3 @@
+# Recommendations 20250624_025516
+- Include `.env` example instructions in future release notes to avoid confusion
+- Consider auto-generating a secure `RFC_PASSWORD` during `prepare.py` if missing

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -526,6 +526,7 @@ Now we can configure Agent Zero - select models, settings, API Keys etc. Refer t
 
 ## 7. Configure Agent Zero RFC
 Agent Zero needs to be configured further to redirect some functions to the Docker container. This is crucial for development as A0 needs to run in a standardized environment to support all features.
+Before proceeding, add a value for `RFC_PASSWORD` in your `.env` file.  This password must match between your local and Docker instances and is required for remote function calls.
 1. Go in "Settings" page in the Web UI of your local instance and go in the "Development" section.
 2. Set "RFC Destination URL" to `http://localhost`
 3. Set the two ports (HTTP and SSH) to the ones used when creating the Docker container

--- a/example.env
+++ b/example.env
@@ -23,6 +23,9 @@ LM_STUDIO_BASE_URL="http://127.0.0.1:1234/v1"
 OPEN_ROUTER_BASE_URL="https://openrouter.ai/api/v1"
 SAMBANOVA_BASE_URL="https://fast-api.snova.ai/v1"
 
+# Password for Remote Function Calls between instances
+RFC_PASSWORD=
+
 
 TOKENIZERS_PARALLELISM=true
 PYDEVD_DISABLE_FILE_VALIDATION=1

--- a/python/helpers/runtime.py
+++ b/python/helpers/runtime.py
@@ -91,7 +91,9 @@ async def handle_rfc(rfc_call: rfc.RFCCall):
 def _get_rfc_password() -> str:
     password = dotenv.get_dotenv_value(dotenv.KEY_RFC_PASSWORD)
     if not password:
-        raise Exception("No RFC password, cannot handle RFC calls.")
+        raise Exception(
+            "RFC password not set. Set RFC_PASSWORD in your .env or through the settings page to enable remote function calls."
+        )
     return password
 
 


### PR DESCRIPTION
## Summary
- add RFC_PASSWORD placeholder to example env file
- document RFC_PASSWORD setup in README quick start
- clarify RFC instructions in installation guide
- improve runtime missing password message

## Testing
- `python -m py_compile python/helpers/runtime.py`


------
https://chatgpt.com/codex/tasks/task_e_685a12ada844832a85c9ba6250594e65

## Summary by Sourcery

Document and enforce the RFC_PASSWORD environment variable for remote function calls across setup guides and runtime behavior.

Enhancements:
- Improve runtime exception message to clearly instruct setting RFC_PASSWORD when missing

Documentation:
- Add RFC_PASSWORD placeholder to example.env and instruct copying example.env to .env in README quick start
- Document RFC_PASSWORD setup requirement in README.md and installation guide before configuring RFC destinations

Chores:
- Add DIFF_20250624_025516.md and RECOMMENDATIONS_20250624_025516.md logs