### PR TITLE
Add Warp.dev replica skeleton

### DIFF
--- a/DIFF_20250704_125851.md
+++ b/DIFF_20250704_125851.md
@@ -1,0 +1,82 @@
+diff --git a/deploy/proxmox/README.md b/deploy/proxmox/README.md
+new file mode 100644
+index 0000000..6b5145a
+--- /dev/null
++++ b/deploy/proxmox/README.md
+@@ -0,0 +1,33 @@
++# Deploying Agent Zero on Proxmox
++
++This guide explains how to launch Agent Zero in an LXC container on a Proxmox server.
++
++## Prerequisites
++- A running Proxmox VE host with access to an Ubuntu template (e.g. `ubuntu-22.04`)
++- Sufficient privileges to create containers
++- Internet access from the Proxmox host to pull Docker images
++
++## Steps
++1. **Download a base template**
++   ```bash
++   pveam update
++   pveam download local ubuntu-22.04-standard_20240429
++   ```
++2. **Create the container**
++   ```bash
++   ./create_lxc.sh <VMID> <storage>
++   ```
++   Replace `<VMID>` with an unused ID and `<storage>` with the storage target (for example `local-lvm`).
++3. **Configure API endpoints**
++   After creation the script installs Docker and launches the Agent Zero container. Edit the `.env` file inside the container to point to your API endpoints:
++   ```bash
++   OLLAMA_BASE_URL=http://host.docker.internal:11434
++   OPEN_ROUTER_BASE_URL=https://openrouter.ai/api/v1
++   # add any other endpoints here
++   ```
++4. **Access the Web UI**
++   By default port `80` of the container is exposed. Navigate to `http://<container_ip>` to open Agent Zero.
++
++## MCP Servers
++If you run separate MCP servers, add them through the settings UI after the first launch or edit `tmp/settings.json` in the container.
++
+diff --git a/deploy/proxmox/create_lxc.sh b/deploy/proxmox/create_lxc.sh
+new file mode 100755
+index 0000000..2e104dc
+--- /dev/null
++++ b/deploy/proxmox/create_lxc.sh
+@@ -0,0 +1,37 @@
++#!/bin/bash
++# Create and start an Agent Zero LXC container on Proxmox
++
++set -e
++
++if [ $# -lt 2 ]; then
++  echo "Usage: $0 <VMID> <storage> [bridge=vmbr0]" >&2
++  exit 1
++fi
++
++VMID=$1
++STORAGE=$2
++BRIDGE=${3:-vmbr0}
++
++TEMPLATE=local:vztmpl/ubuntu-22.04-standard_20240429.tar.zst
++HOSTNAME=agent-zero-$VMID
++MEMORY=4096
++CORES=2
++
++pct create "$VMID" "$TEMPLATE" \
++  --rootfs "$STORAGE":8 \
++  --hostname "$HOSTNAME" \
++  --memory "$MEMORY" \
++  --cores "$CORES" \
++  --net0 name=eth0,bridge="$BRIDGE",ip=dhcp
++
++pct start "$VMID"
++pct exec "$VMID" -- apt-get update
++pct exec "$VMID" -- apt-get install -y docker.io
++
++pct push "$VMID" ../../example.env /root/.agent-zero.env
++
++pct exec "$VMID" -- docker run -d --name agent-zero \
++  --env-file /root/.agent-zero.env \
++  -p 80:80 frdel/agent-zero-run:latest
++
++echo "Container $VMID created and Agent Zero started."

--- a/DIFF_20250704_182805.md
+++ b/DIFF_20250704_182805.md
@@ -1,0 +1,120 @@
+diff --git a/config/mcp_servers.json b/config/mcp_servers.json
+new file mode 100644
+index 0000000..1da0757
+--- /dev/null
++++ b/config/mcp_servers.json
+@@ -0,0 +1,18 @@
++{
++    "mcp_servers": [
++        {
++            "name": "local_tools",
++            "command": "python3",
++            "args": ["mcp_scripts/local_server.py"],
++            "disabled": false
++        },
++        {
++            "name": "remote_api",
++            "url": "https://api.example.com/mcp",
++            "headers": {
++                "Authorization": "Bearer <TOKEN>"
++            },
++            "disabled": false
++        }
++    ]
++}
+diff --git a/docs/warpdev/README.md b/docs/warpdev/README.md
+new file mode 100644
+index 0000000..b32c90e
+--- /dev/null
++++ b/docs/warpdev/README.md
+@@ -0,0 +1,22 @@
++# Warp.dev Replica Project
++
++This directory collects project planning notes for creating a GUI and TUI inspired by [Warp.dev](https://www.warp.dev). The goal is to leverage Agent Zero's capabilities while providing a modern terminal experience.
++
++## Planned Features
++
++- Command palette with searchable history
++- AI-assisted command suggestions
++- Split panes and session management
++- Local and remote file browser
++- Integration with Agent Zero tools and MCP servers
++
++## Project Tasks
++
++1. Design interface mock-ups and user flows.
++2. Build a prototype TUI using [Textual](https://textual.textualize.io).
++3. Create a web-based GUI mirroring the TUI functionality.
++4. Connect the interface to Agent Zero's API endpoints.
++5. Allow configuration of MCP servers through a settings screen.
++6. Package a desktop application using Electron or Tauri (optional).
++
++See `dependencies.md` for the list of suggested Python packages.
+diff --git a/docs/warpdev/dependencies.md b/docs/warpdev/dependencies.md
+new file mode 100644
+index 0000000..a4b8bbe
+--- /dev/null
++++ b/docs/warpdev/dependencies.md
+@@ -0,0 +1,12 @@
++# Warp.dev Replica Dependencies
++
++Suggested Python packages for building the Warp.dev inspired interface:
++
++- `textual` – rapid TUI framework with rich widgets
++- `rich` – rendering engine used by Textual
++- `prompt_toolkit` – advanced command line editing features
++- `websockets` – real-time communication for the web UI
++- `fastapi` – lightweight backend API for UI integration
++
++These packages are not included by default in Agent Zero's requirements.
++Install them when working on the replica project.
+diff --git a/requirements.txt b/requirements.txt
+index b68470b..6497979 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -42,3 +42,6 @@ pdf2image==1.17.0
+ crontab==1.0.1
+ pathspec>=0.12.1
+ psutil>=7.0.0
++textual>=3.5.0
++rich>=13.7.0
++prompt_toolkit>=3.0.43
+diff --git a/warpdev/__init__.py b/warpdev/__init__.py
+new file mode 100644
+index 0000000..001f668
+--- /dev/null
++++ b/warpdev/__init__.py
+@@ -0,0 +1,5 @@
++"""Warp.dev inspired interface for Agent Zero."""
++
++from .app import WarpDevApp
++
++__all__ = ["WarpDevApp"]
+diff --git a/warpdev/app.py b/warpdev/app.py
+new file mode 100644
+index 0000000..6944b70
+--- /dev/null
++++ b/warpdev/app.py
+@@ -0,0 +1,22 @@
++from textual.app import App, ComposeResult
++from textual.widgets import Header, Footer, TextLog
++
++
++class WarpDevApp(App):
++    """Minimal TUI inspired by Warp.dev."""
++
++    CSS_PATH = None
++
++    def compose(self) -> ComposeResult:
++        yield Header(show_clock=True)
++        self.log = TextLog(highlight=True)
++        yield self.log
++        yield Footer()
++
++    async def on_mount(self) -> None:
++        self.log.write("Warp.dev replica is under construction.")
++        self.log.write("Integrate with Agent Zero APIs here.")
++
++
++if __name__ == "__main__":
++    WarpDevApp().run()

--- a/RECOMMENDATIONS_20250704_125851.md
+++ b/RECOMMENDATIONS_20250704_125851.md
@@ -1,0 +1,2 @@
+- Provide a helper script to update `.env` automatically with user-provided API keys before pushing it into the container.
+- Offer an optional parameter in `create_lxc.sh` for memory and CPU settings so deployments can be tuned for available hardware.

--- a/RECOMMENDATIONS_20250704_182805.md
+++ b/RECOMMENDATIONS_20250704_182805.md
@@ -1,0 +1,3 @@
+- Explore using Textual's CSS theming to better mirror Warp.dev's look and feel.
+- Provide a script to convert `config/mcp_servers.json` into the `tmp/settings.json` format for easier configuration.
+- Consider bundling the WarpDev TUI as a standalone binary with PyInstaller for simple distribution.

--- a/config/mcp_servers.json
+++ b/config/mcp_servers.json
@@ -1,0 +1,18 @@
+{
+    "mcp_servers": [
+        {
+            "name": "local_tools",
+            "command": "python3",
+            "args": ["mcp_scripts/local_server.py"],
+            "disabled": false
+        },
+        {
+            "name": "remote_api",
+            "url": "https://api.example.com/mcp",
+            "headers": {
+                "Authorization": "Bearer <TOKEN>"
+            },
+            "disabled": false
+        }
+    ]
+}

--- a/deploy/proxmox/README.md
+++ b/deploy/proxmox/README.md
@@ -1,0 +1,33 @@
+# Deploying Agent Zero on Proxmox
+
+This guide explains how to launch Agent Zero in an LXC container on a Proxmox server.
+
+## Prerequisites
+- A running Proxmox VE host with access to an Ubuntu template (e.g. `ubuntu-22.04`)
+- Sufficient privileges to create containers
+- Internet access from the Proxmox host to pull Docker images
+
+## Steps
+1. **Download a base template**
+   ```bash
+   pveam update
+   pveam download local ubuntu-22.04-standard_20240429
+   ```
+2. **Create the container**
+   ```bash
+   ./create_lxc.sh <VMID> <storage>
+   ```
+   Replace `<VMID>` with an unused ID and `<storage>` with the storage target (for example `local-lvm`).
+3. **Configure API endpoints**
+   After creation the script installs Docker and launches the Agent Zero container. Edit the `.env` file inside the container to point to your API endpoints:
+   ```bash
+   OLLAMA_BASE_URL=http://host.docker.internal:11434
+   OPEN_ROUTER_BASE_URL=https://openrouter.ai/api/v1
+   # add any other endpoints here
+   ```
+4. **Access the Web UI**
+   By default port `80` of the container is exposed. Navigate to `http://<container_ip>` to open Agent Zero.
+
+## MCP Servers
+If you run separate MCP servers, add them through the settings UI after the first launch or edit `tmp/settings.json` in the container.
+

--- a/deploy/proxmox/create_lxc.sh
+++ b/deploy/proxmox/create_lxc.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Create and start an Agent Zero LXC container on Proxmox
+
+set -e
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <VMID> <storage> [bridge=vmbr0]" >&2
+  exit 1
+fi
+
+VMID=$1
+STORAGE=$2
+BRIDGE=${3:-vmbr0}
+
+TEMPLATE=local:vztmpl/ubuntu-22.04-standard_20240429.tar.zst
+HOSTNAME=agent-zero-$VMID
+MEMORY=4096
+CORES=2
+
+pct create "$VMID" "$TEMPLATE" \
+  --rootfs "$STORAGE":8 \
+  --hostname "$HOSTNAME" \
+  --memory "$MEMORY" \
+  --cores "$CORES" \
+  --net0 name=eth0,bridge="$BRIDGE",ip=dhcp
+
+pct start "$VMID"
+pct exec "$VMID" -- apt-get update
+pct exec "$VMID" -- apt-get install -y docker.io
+
+pct push "$VMID" ../../example.env /root/.agent-zero.env
+
+pct exec "$VMID" -- docker run -d --name agent-zero \
+  --env-file /root/.agent-zero.env \
+  -p 80:80 frdel/agent-zero-run:latest
+
+echo "Container $VMID created and Agent Zero started."

--- a/docs/warpdev/README.md
+++ b/docs/warpdev/README.md
@@ -1,0 +1,22 @@
+# Warp.dev Replica Project
+
+This directory collects project planning notes for creating a GUI and TUI inspired by [Warp.dev](https://www.warp.dev). The goal is to leverage Agent Zero's capabilities while providing a modern terminal experience.
+
+## Planned Features
+
+- Command palette with searchable history
+- AI-assisted command suggestions
+- Split panes and session management
+- Local and remote file browser
+- Integration with Agent Zero tools and MCP servers
+
+## Project Tasks
+
+1. Design interface mock-ups and user flows.
+2. Build a prototype TUI using [Textual](https://textual.textualize.io).
+3. Create a web-based GUI mirroring the TUI functionality.
+4. Connect the interface to Agent Zero's API endpoints.
+5. Allow configuration of MCP servers through a settings screen.
+6. Package a desktop application using Electron or Tauri (optional).
+
+See `dependencies.md` for the list of suggested Python packages.

--- a/docs/warpdev/dependencies.md
+++ b/docs/warpdev/dependencies.md
@@ -1,0 +1,12 @@
+# Warp.dev Replica Dependencies
+
+Suggested Python packages for building the Warp.dev inspired interface:
+
+- `textual` – rapid TUI framework with rich widgets
+- `rich` – rendering engine used by Textual
+- `prompt_toolkit` – advanced command line editing features
+- `websockets` – real-time communication for the web UI
+- `fastapi` – lightweight backend API for UI integration
+
+These packages are not included by default in Agent Zero's requirements.
+Install them when working on the replica project.

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,6 @@ pdf2image==1.17.0
 crontab==1.0.1
 pathspec>=0.12.1
 psutil>=7.0.0
+textual>=3.5.0
+rich>=13.7.0
+prompt_toolkit>=3.0.43

--- a/warpdev/__init__.py
+++ b/warpdev/__init__.py
@@ -1,0 +1,5 @@
+"""Warp.dev inspired interface for Agent Zero."""
+
+from .app import WarpDevApp
+
+__all__ = ["WarpDevApp"]

--- a/warpdev/app.py
+++ b/warpdev/app.py
@@ -1,0 +1,22 @@
+from textual.app import App, ComposeResult
+from textual.widgets import Header, Footer, TextLog
+
+
+class WarpDevApp(App):
+    """Minimal TUI inspired by Warp.dev."""
+
+    CSS_PATH = None
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        self.log = TextLog(highlight=True)
+        yield self.log
+        yield Footer()
+
+    async def on_mount(self) -> None:
+        self.log.write("Warp.dev replica is under construction.")
+        self.log.write("Integrate with Agent Zero APIs here.")
+
+
+if __name__ == "__main__":
+    WarpDevApp().run()


### PR DESCRIPTION
## Summary
- add example MCP configuration
- outline Warp.dev-inspired interface and dependencies
- create minimal TUI using Textual
- list new dependencies in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'attr')*

------
https://chatgpt.com/codex/tasks/task_e_6867cf6c5a40832aafb5f42f46fe156b

## Summary by Sourcery

Introduce the skeleton for a Warp.dev-inspired UI with a minimal Textual TUI, include example configuration, documentation, and Proxmox deployment scripts

New Features:
- Add WarpDevApp class providing a minimal Textual-based TUI skeleton

Enhancements:
- Introduce example config/mcp_servers.json for MCP server setup
- Provide initial project planning and dependency documentation for the Warp.dev replica

Build:
- Update requirements.txt to include textual, rich, and prompt_toolkit

Deployment:
- Add Proxmox deployment guide and create_lxc.sh script for Agent Zero LXC provisioning

Documentation:
- Add warpdev/README.md and dependencies.md outlining the replica project
- Add deploy/proxmox/README.md detailing Proxmox deployment steps