### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,118 @@
+name: Agent Zero CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-test-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install ruff bandit safety pip-audit vulture mypy
+
+    - name: Lint and auto-fix with ruff
+      run: ruff . --fix
+
+    - name: Commit lint fixes
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "chore: apply lint fixes"
+        branch: ${{ github.head_ref }}
+
+    - name: Run mypy
+      run: mypy .
+
+    - name: Run tests
+      run: pytest tests -q 2>&1 | tee test.log
+
+    - name: Scan for secrets
+      uses: gitleaks/gitleaks-action@v2
+      with:
+        fail: false
+        report-format: json
+        report-path: gitleaks-report.json
+
+    - name: Security scan with Bandit
+      run: bandit -r . -f json -o bandit-report.json
+
+    - name: Safety vulnerability check
+      run: safety check -r requirements.txt --full-report > safety-report.txt
+
+    - name: Dependency vulnerability audit
+      run: pip-audit -r requirements.txt --output pip-audit-results.txt
+
+    - name: Unused code check with vulture
+      run: vulture . > vulture-report.txt
+
+    - name: Shell script linting
+      uses: ludeeus/action-shellcheck@v2
+
+    - name: Validate workflows
+      uses: rhysd/actionlint@v1
+
+    - name: Upload logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: ci-logs
+        path: |
+          test.log
+          gitleaks-report.json
+          bandit-report.json
+          safety-report.txt
+          pip-audit-results.txt
+          vulture-report.txt
+
+  build-docker:
+    needs: lint-test-scan
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: false
+        tags: agent-zero:ci
+
+    - name: Scan Docker image with Trivy
+      uses: aquasecurity/trivy-action@v0.13.1
+      with:
+        image-ref: agent-zero:ci
+        format: table
+        output: trivy-report.txt
+
+    - name: Upload Docker scan
+      uses: actions/upload-artifact@v4
+      with:
+        name: docker-scan
+        path: trivy-report.txt
+
+  codeql-analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+    - uses: actions/checkout@v4
+    - uses: github/codeql-action/init@v3
+      with:
+        languages: python
+    - uses: github/codeql-action/analyze@v3

--- a/DIFF_20250707_121042.md
+++ b/DIFF_20250707_121042.md
@@ -1,0 +1,6 @@
+- Created .github/workflows/ci.yml with CI/CD pipeline.
+  - Lints with ruff and auto-fixes code, committing changes automatically.
+  - Runs mypy, pytest, bandit, safety, pip-audit, vulture, shellcheck and actionlint.
+  - Scans for secrets using gitleaks and uploads logs as artifacts.
+  - Builds Docker image with Buildx, scans with Trivy and uploads results.
+  - Performs GitHub CodeQL analysis.

--- a/RECOMMENDATIONS_20250707_121042.md
+++ b/RECOMMENDATIONS_20250707_121042.md
@@ -1,0 +1,4 @@
+- Set up Dependabot for automated dependency updates.
+- Consider caching Python packages to speed up CI.
+- Add deployment steps to push Docker image to registry when credentials are provided.
+- Integrate artifact analysis in the agent to provide automated improvement suggestions.


### PR DESCRIPTION
## Summary
- add CI workflow with linting, tests, security scans, and docker build
- document workflow addition in DIFF and RECOMMENDATIONS files

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb8e21224832a9e823a782dd341c9