### PR TITLE
Add tests and Hetzner deploy script

### DIFF
--- a/DIFF_20250709_042844.md
+++ b/DIFF_20250709_042844.md
@@ -1,0 +1,132 @@
+### Diff for 20250709_042844
+diff --git a/DIFF_20250709_042844.md b/DIFF_20250709_042844.md
+new file mode 100644
+index 0000000..8486c25
+--- /dev/null
++++ b/DIFF_20250709_042844.md
+@@ -0,0 +1 @@
++### Diff for 20250709_042844
+diff --git a/RECOMMENDATIONS_20250709_042844.md b/RECOMMENDATIONS_20250709_042844.md
+new file mode 100644
+index 0000000..f072d0d
+--- /dev/null
++++ b/RECOMMENDATIONS_20250709_042844.md
+@@ -0,0 +1 @@
++### Recommendations 20250709_042844
+diff --git a/deploy/hetzner/setup_agent_zero.sh b/deploy/hetzner/setup_agent_zero.sh
+new file mode 100755
+index 0000000..400893e
+--- /dev/null
++++ b/deploy/hetzner/setup_agent_zero.sh
+@@ -0,0 +1,60 @@
++#!/bin/bash
++set -euo pipefail
++
++# Install dependencies
++sudo apt-get update
++sudo apt-get install -y git python3 python3-venv python3-pip nginx
++
++# Clone repository
++sudo mkdir -p /opt/agent-zero
++sudo chown "$USER" /opt/agent-zero
++if [ ! -d /opt/agent-zero/.git ]; then
++    git clone https://github.com/cloudcurio/agent-zero.git /opt/agent-zero
++fi
++cd /opt/agent-zero
++
++# Setup Python environment
++python3 -m venv venv
++source venv/bin/activate
++pip install --upgrade pip
++pip install -r requirements.txt
++
++# Create systemd service
++sudo tee /etc/systemd/system/agent-zero.service >/dev/null <<'SERVICE'
++[Unit]
++Description=Agent Zero Service
++After=network.target
++
++[Service]
++Type=simple
++User=%i
++WorkingDirectory=/opt/agent-zero
++ExecStart=/opt/agent-zero/venv/bin/python3 run_ui.py
++Restart=always
++
++[Install]
++WantedBy=multi-user.target
++SERVICE
++
++sudo systemctl daemon-reload
++sudo systemctl enable agent-zero.service
++sudo systemctl start agent-zero.service
++
++# Configure Nginx
++sudo tee /etc/nginx/sites-available/agent-zero.conf >/dev/null <<'NGINX'
++server {
++    listen 80;
++    server_name cloudcurio.cc;
++    location /agent-zero/ {
++        proxy_pass http://127.0.0.1:50001/;
++        proxy_set_header Host $host;
++        proxy_set_header X-Real-IP $remote_addr;
++        proxy_set_header X-Forwarded-Proto $scheme;
++    }
++}
++NGINX
++
++sudo ln -sf /etc/nginx/sites-available/agent-zero.conf /etc/nginx/sites-enabled/agent-zero.conf
++sudo nginx -s reload
++
++echo "Deployment complete. Visit http://cloudcurio.cc/agent-zero" 
+diff --git a/pytest.ini b/pytest.ini
+new file mode 100644
+index 0000000..c34e94f
+--- /dev/null
++++ b/pytest.ini
+@@ -0,0 +1,4 @@
++[pytest]
++testpaths = tests
++pythonpath = .
++addopts = -ra
+diff --git a/tests/conftest.py b/tests/conftest.py
+new file mode 100644
+index 0000000..f0efcba
+--- /dev/null
++++ b/tests/conftest.py
+@@ -0,0 +1,4 @@
++import sys, os
++sys.path.insert(0, os.path.abspath('.'))
++
++collect_ignore = ['python/api/backup_test.py']
+diff --git a/tests/test_dotenv_helpers.py b/tests/test_dotenv_helpers.py
+new file mode 100644
+index 0000000..fc6bdbb
+--- /dev/null
++++ b/tests/test_dotenv_helpers.py
+@@ -0,0 +1,11 @@
++from pathlib import Path
++import os
++import importlib
++from python.helpers import dotenv, files
++
++
++def test_save_and_get_dotenv_value(tmp_path, monkeypatch):
++    monkeypatch.setattr(files, "get_base_dir", lambda: tmp_path)
++    dotenv.save_dotenv_value("TEST_KEY", "VALUE")
++    assert dotenv.get_dotenv_value("TEST_KEY") == "VALUE"
++    assert (tmp_path / ".env").read_text().strip().split("=")[1] == "VALUE"
+diff --git a/tests/test_file_helpers.py b/tests/test_file_helpers.py
+new file mode 100644
+index 0000000..f0a7d54
+--- /dev/null
++++ b/tests/test_file_helpers.py
+@@ -0,0 +1,8 @@
++from pathlib import Path
++from python.helpers import files
++
++
++def test_get_abs_path(tmp_path, monkeypatch):
++    monkeypatch.setattr(files, "get_base_dir", lambda: tmp_path)
++    path = files.get_abs_path("data", "file.txt")
++    assert Path(path) == tmp_path / "data" / "file.txt"

--- a/RECOMMENDATIONS_20250709_042844.md
+++ b/RECOMMENDATIONS_20250709_042844.md
@@ -1,0 +1,6 @@
+### Recommendations 20250709_042844
+- Add pytest.ini to simplify running tests and ensure 'python' package is found.
+- Ignore python/api/backup_test.py during collection to avoid import errors.
+- Added helper tests for dotenv and file utilities as a starting point for full coverage.
+- Provided a deployment script for Hetzner servers using Nginx at cloudcurio.cc/agent-zero.
+- Ensure requirements.txt packages are installed before running tests.

--- a/deploy/hetzner/setup_agent_zero.sh
+++ b/deploy/hetzner/setup_agent_zero.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install dependencies
+sudo apt-get update
+sudo apt-get install -y git python3 python3-venv python3-pip nginx
+
+# Clone repository
+sudo mkdir -p /opt/agent-zero
+sudo chown "$USER" /opt/agent-zero
+if [ ! -d /opt/agent-zero/.git ]; then
+    git clone https://github.com/cloudcurio/agent-zero.git /opt/agent-zero
+fi
+cd /opt/agent-zero
+
+# Setup Python environment
+python3 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# Create systemd service
+sudo tee /etc/systemd/system/agent-zero.service >/dev/null <<'SERVICE'
+[Unit]
+Description=Agent Zero Service
+After=network.target
+
+[Service]
+Type=simple
+User=%i
+WorkingDirectory=/opt/agent-zero
+ExecStart=/opt/agent-zero/venv/bin/python3 run_ui.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+sudo systemctl daemon-reload
+sudo systemctl enable agent-zero.service
+sudo systemctl start agent-zero.service
+
+# Configure Nginx
+sudo tee /etc/nginx/sites-available/agent-zero.conf >/dev/null <<'NGINX'
+server {
+    listen 80;
+    server_name cloudcurio.cc;
+    location /agent-zero/ {
+        proxy_pass http://127.0.0.1:50001/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+NGINX
+
+sudo ln -sf /etc/nginx/sites-available/agent-zero.conf /etc/nginx/sites-enabled/agent-zero.conf
+sudo nginx -s reload
+
+echo "Deployment complete. Visit http://cloudcurio.cc/agent-zero" 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+addopts = -ra

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys, os
+sys.path.insert(0, os.path.abspath('.'))
+
+collect_ignore = ['python/api/backup_test.py']

--- a/tests/test_dotenv_helpers.py
+++ b/tests/test_dotenv_helpers.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import os
+import importlib
+from python.helpers import dotenv, files
+
+
+def test_save_and_get_dotenv_value(tmp_path, monkeypatch):
+    monkeypatch.setattr(files, "get_base_dir", lambda: tmp_path)
+    dotenv.save_dotenv_value("TEST_KEY", "VALUE")
+    assert dotenv.get_dotenv_value("TEST_KEY") == "VALUE"
+    assert (tmp_path / ".env").read_text().strip().split("=")[1] == "VALUE"

--- a/tests/test_file_helpers.py
+++ b/tests/test_file_helpers.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+from python.helpers import files
+
+
+def test_get_abs_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(files, "get_base_dir", lambda: tmp_path)
+    path = files.get_abs_path("data", "file.txt")
+    assert Path(path) == tmp_path / "data" / "file.txt"


### PR DESCRIPTION
## Summary
- add pytest.ini for easier test running
- ignore python/api/backup_test.py
- add simple helper unit tests
- create deployment script for Hetzner with nginx

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686def6008cc832a8971764a313e13e2

## Summary by Sourcery

Add test configuration, initial helper tests, and a Hetzner deployment script to automate server setup and application testing

New Features:
- Add a Hetzner deployment script that provisions a server with dependencies, sets up a systemd service, and configures Nginx

Enhancements:
- Introduce pytest.ini and conftest.py to streamline test discovery and ignore legacy tests

Tests:
- Add initial unit tests for dotenv and file helper modules

Chores:
- Add diff metadata and recommendations files for review